### PR TITLE
fix: forward Input component refs

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,9 +2,10 @@ import * as React from "react"
 
 import { cn } from "../../lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type = "text", ...props }, ref) => (
     <input
+      ref={ref}
       type={type}
       data-slot="input"
       className={cn(
@@ -16,6 +17,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       {...props}
     />
   )
-}
+)
+Input.displayName = "Input"
 
 export { Input }


### PR DESCRIPTION
## Summary
- forward refs through Input component for better integration
- default Input to type="text"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components; Do not use @ts-nocheck)*

------
https://chatgpt.com/codex/tasks/task_e_689dee87b3a8832f8c62959b1d1d8812